### PR TITLE
Add `dbname` to client instantiation for automated tests

### DIFF
--- a/wsdb/tests/test_catalogues.py
+++ b/wsdb/tests/test_catalogues.py
@@ -6,7 +6,7 @@ from wsdb import WSDB
 class TestWSDBClient(unittest.TestCase):
 
     def setUp(self):
-        self.client = WSDB()
+        self.client = WSDB(dbname='wsdb')
 
     def tearDown(self):
         self.client.close()
@@ -32,6 +32,3 @@ class TestWSDBCatalogues(TestWSDBClient):
 
         for catalogue_name in catalogue_names:
             self.assertIsInstance(catalogue_name, (str, unicode))
-
-
-        


### PR DESCRIPTION
Does this fix Travis's automated tests?

See the failed builds for https://github.com/GOTO-OBS/goto-wsdb/pull/1
The resulting error is
```python
TypeError: missing dsn and no parameters
```
due to a missing `dbname=...` argument to `WSDB()`.

Alternatively, a `~/.goto-wsdb.yaml` may do the trick, but that makes the tests dependent on a configuration file.
